### PR TITLE
Add long press channel reset

### DIFF
--- a/python/camera_control
+++ b/python/camera_control
@@ -133,7 +133,7 @@ def up_btn_held():
 def activate_channel(cnum):
   print("Activating {}".format(channels[cnum]))
   sys.stdout.flush()
-  retval=os.system("sudo -n systemctl start {}".format(channels[cnum]))
+  retval=os.system("sudo -n systemctl restart {}".format(channels[cnum]))
   return retval
 
 def channel_up(skip_broken=False):

--- a/python/camera_control
+++ b/python/camera_control
@@ -39,6 +39,9 @@ except BadPinFactory:
   sys.stdout.flush()
   ubtn=None
   dbtn=None
+ubtn_held=False
+bbtn_held=False
+
 
 
 ##################################
@@ -70,33 +73,58 @@ def flush_fifo(f):
   print("done flushing fifo")
   sys.stdout.flush()
 
+def set_dbtn_held(value):
+    global dbtn_held
+    dbtn_held=value
+    print("Setting dbtn_held:",dbtn_held)
+def set_ubtn_held(value):
+    global ubtn_held
+    ubtn_held=value
+    print("Setting ubtn_held:",ubtn_held)
+
 def down_btn_pressed():
-    global current_channel
     print("Caught Down Button Press") 
+    set_dbtn_held(False)
+
+def down_btn_released():
+    global current_channel
+    print("Caught Down Button Release") 
     print(ubtn)
     print(dbtn)
     sys.stdout.flush()
-    current_channel=channel_down(True)
+    if dbtn_held:
+      print("Down Button Long Press Detected, Ignoring Release Event",dbtn_held) 
+    else:
+      current_channel=channel_down(True)
 
 def down_btn_held():
     global current_channel
-    print("Caught Down Button Long Hold") 
+    print("Caught Down Button Long Hold")
+    set_dbtn_held(True)
     print(ubtn)
     print(dbtn)
     sys.stdout.flush()
     current_channel=channel_jump(default_index)
 
 def up_btn_pressed():
-    global current_channel
     print("Caught Up Button Press") 
+    set_ubtn_held(False)
+
+def up_btn_released():
+    global current_channel
+    print("Caught Up Button Release") 
     print(ubtn)
     print(dbtn)
     sys.stdout.flush()
-    current_channel=channel_up(True)
+    if ubtn_held:
+      print("Up Button Long Press Detected, Ignoring Release Event",ubtn_held) 
+    else:
+      current_channel=channel_up(True)
 
 def up_btn_held():
     global current_channel
     print("Caught Up Button Long Hold") 
+    set_ubtn_held(True)
     print(ubtn)
     print(dbtn)
     sys.stdout.flush()
@@ -189,13 +217,17 @@ retval=os.system("sudo -n fbi --noverbose -a -T 1 /etc/omxplayer/back.png")
 retval=activate_channel(current_channel)
 
 if ubtn: 
+    ubtn.when_released=up_btn_released
     ubtn.when_pressed=up_btn_pressed
     ubtn.when_held=up_btn_held
     ubtn.hold_time=2
+    ubtn_pressed=False
 if dbtn: 
+    dbtn.when_released=down_btn_released
     dbtn.when_pressed=down_btn_pressed
     dbtn.when_held=down_btn_held
     dbtn.hold_time=2
+    dbtn_pressed=False
 
 print("Entering fifo wait loop")
 sys.stdout.flush()

--- a/python/camera_control
+++ b/python/camera_control
@@ -21,7 +21,6 @@ channels=[
           "SIDEBYSIDE@1","SIDEBYSIDE@2","SIDEBYSIDE@3",
           "SIDEBYSIDE@4","SIDEBYSIDE@5","SIDEBYSIDE@6"
          ]
-
 fifo_path="/tmp/cameractl.fifo"
 
 # GPIO Button pins
@@ -40,6 +39,7 @@ except BadPinFactory:
   sys.stdout.flush()
   ubtn=None
   dbtn=None
+
 
 ##################################
 ##
@@ -78,6 +78,14 @@ def down_btn_pressed():
     sys.stdout.flush()
     current_channel=channel_down(True)
 
+def down_btn_held():
+    global current_channel
+    print("Caught Down Button Long Hold") 
+    print(ubtn)
+    print(dbtn)
+    sys.stdout.flush()
+    current_channel=channel_jump(default_index)
+
 def up_btn_pressed():
     global current_channel
     print("Caught Up Button Press") 
@@ -85,6 +93,14 @@ def up_btn_pressed():
     print(dbtn)
     sys.stdout.flush()
     current_channel=channel_up(True)
+
+def up_btn_held():
+    global current_channel
+    print("Caught Up Button Long Hold") 
+    print(ubtn)
+    print(dbtn)
+    sys.stdout.flush()
+    current_channel=channel_jump(default_index)
 
 def activate_channel(cnum):
   print("Activating {}".format(channels[cnum]))
@@ -145,6 +161,21 @@ def channel_down(skip_broken=False):
     return current_channel
   return next_channel
 
+def channel_jump(requested_channel=None):
+  global current_channel
+  if requested_channel:
+    retval=activate_channel(requested_channel)
+    if retval == 0: 
+      print("chan Jump: {}:{} -> {}:{}".format(current_channel,channels[current_channel],requested_channel,channels[requested_channel]))
+      sys.stdout.flush()
+      return requested_channel
+    else:
+      print("ERROR: chan Jump: {}:{} -> {}:{}".format(current_channel,channels[current_channel],requested_channel,channels[requested_channel]))
+      sys.stdout.flush()
+      return current_channel
+  return current_channel
+
+
 if os.path.exists(fifo_path): os.remove(fifo_path) 
 
 os.mkfifo(fifo_path)
@@ -157,8 +188,14 @@ fifo=os.fdopen(fd)
 retval=os.system("sudo -n fbi --noverbose -a -T 1 /etc/omxplayer/back.png")
 retval=activate_channel(current_channel)
 
-if ubtn: ubtn.when_pressed=up_btn_pressed
-if dbtn: dbtn.when_pressed=down_btn_pressed
+if ubtn: 
+    ubtn.when_pressed=up_btn_pressed
+    ubtn.when_held=up_btn_held
+    ubtn.hold_time=2
+if dbtn: 
+    dbtn.when_pressed=down_btn_pressed
+    dbtn.when_held=down_btn_held
+    dbtn.hold_time=2
 
 print("Entering fifo wait loop")
 sys.stdout.flush()


### PR DESCRIPTION
This makes it possible to jump back to default view with a 2 second long press on either button.

Provides:
1. quick jump back to default
2. should gives as an easy way to reset views that come up blank or partially blank on tv power on.
3. backup mechanism if we lose a mechanical button so we can easily get back to default.